### PR TITLE
Take out the trash

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,11 +5,13 @@ History
 0.2.1 (Current Version)
 -----------------------
 
+* Fix bug in ``slurm_runner.do_job`` which caused job duplication when race conditions on lock object creation occur (:issue:`3`)
+
 
 0.2.0 (2017-07-31)
 ------------------
 
-* Fix interactive bug -- call interactive=True on `slurm_runner.run_interactive()` (:issue:`1`)
+* Fix interactive bug -- call interactive=True on ``slurm_runner.run_interactive()`` (:issue:`1`)
 * Add slurm_runner as module-level import
 
 

--- a/jrnr/__init__.py
+++ b/jrnr/__init__.py
@@ -7,7 +7,7 @@ from jrnr.jrnr import slurm_runner
 
 __author__ = """Justin Simcock"""
 __email__ = 'jsimcock@rhg.com'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 _module_imports = (
     slurm_runner,

--- a/jrnr/jrnr.py
+++ b/jrnr/jrnr.py
@@ -451,11 +451,13 @@ def slurm_runner(run_job, filepath, job_spec, onfinish=None):
                     print('{} already done. skipping'.format(task_id))
                     if os.path.exists(lock_file.format('lck')):
                         os.remove(lock_file.format('lck'))
+                    continue
 
                 elif os.path.exists(lock_file.format('err')):
                     print('{} previously errored. skipping'.format(task_id))
                     if os.path.exists(lock_file.format('lck')):
                         os.remove(lock_file.format('lck'))
+                    continue
 
             except OSError:
                 print('{} already in progress. skipping'.format(task_id))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ test_requirements = [
 
 setup(
     name='jrnr',
-    version='0.2.0',
+    version='0.2.1',
     description="Job Runner for Climate Impact Lab Jobs",
     long_description=readme + '\n\n' + history,
     author="Justin Simcock",


### PR DESCRIPTION
 - [x] closes #3 
 - [ ] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 jrnr tests docs``
 - [x] entry in HISTORY.rst

Existing race condition controls failed to skip jobs which fail the race conditions tests in `slurm_runner.do_job`. This fixes the bug.