### PR TITLE
Add optional return_index arg to slurm_runner

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 
 * Fix bug in ``slurm_runner.do_job`` which caused job duplication when race conditions on lock object creation occur (:issue:`3`)
 * Infer filepath from passed function in ``slurm_runner``. Removes need to supply filepath argument in ``slurm_runner`` function calls (:issue:`5`)
+* Adds ``return_index`` parameter to ``slurm_runner`` (:issue:`7`)
 
 0.2.0 (2017-07-31)
 ------------------

--- a/jrnr/__init__.py
+++ b/jrnr/__init__.py
@@ -7,7 +7,7 @@ from jrnr.jrnr import slurm_runner
 
 __author__ = """Justin Simcock"""
 __email__ = 'jsimcock@rhg.com'
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 _module_imports = (
     slurm_runner,

--- a/jrnr/jrnr.py
+++ b/jrnr/jrnr.py
@@ -295,7 +295,40 @@ def _get_call_args(job_spec, index=0):
 
 
 @toolz.curry
-def slurm_runner(run_job, job_spec, filepath=None, onfinish=None):
+def slurm_runner(run_job, job_spec, filepath=None, onfinish=None, return_index=False):
+    '''
+    Decorator to create a SLURM runner job management command-line application
+
+    Parameters
+    ----------
+
+    run_job : function
+        Function executed for each task specified by ``job_spec``. ``run_job``
+        must be of the form ``run_job(metadata, interactive=False, **kwargs)``
+        where ``kwargs`` is the set of keyword terms specified by ``job_spec``.
+    
+    job_spec : tuple of lists of dicts
+        Job specification in the format ``([{kwargs: vals}, ...], [...], ...)``.
+        ``slurm_runner`` will iterate through all combinations of the lists in
+        ``job_spec``, combining paired kwarg dictionaries and passing them as
+        arguments to ``run_job``.
+    
+    filepath : str, optional
+        Path to file to call when running tasks. By default (None), slurm_runner
+        infers the filepath from the location of ``run_job``.
+    
+    onfinish : function, optional
+        Provide a function to call when all jobs have been completed. Default (None)
+        takes no action.
+    
+    return_index : bool, optional
+        Adds a ``task_id`` argument to run_job call with 0-indexed ID of current task
+
+    Returns
+    -------
+    slurm_runner : click.Group
+        A SLURM runner job management command-line application
+    '''
 
     if filepath is None:
         filepath = os.path.abspath(inspect.getfile(run_job))
@@ -485,6 +518,9 @@ def slurm_runner(run_job, job_spec, filepath=None, onfinish=None):
             try:
 
                 job_kwargs = _get_call_args(job_spec, task_id)
+                
+                if return_index:
+                    job_kwargs.update({'task_id': task_id})
 
                 logger.debug('Beginning job\nkwargs:\t{}'.format(
                     pprint.pformat(job_kwargs['metadata'], indent=2)))
@@ -560,6 +596,9 @@ def slurm_runner(run_job, job_spec, filepath=None, onfinish=None):
 
         logger.debug('Beginning job\nkwargs:\t{}'.format(
             pprint.pformat(job_kwargs['metadata'], indent=2)))
+                
+        if return_index:
+             job_kwargs.update({'task_id': task_id})
 
         return run_job(interactive=True, **job_kwargs)
 

--- a/jrnr/jrnr.py
+++ b/jrnr/jrnr.py
@@ -295,7 +295,12 @@ def _get_call_args(job_spec, index=0):
 
 
 @toolz.curry
-def slurm_runner(run_job, job_spec, filepath=None, onfinish=None, return_index=False):
+def slurm_runner(
+        run_job,
+        job_spec,
+        filepath=None,
+        onfinish=None,
+        return_index=False):
     '''
     Decorator to create a SLURM runner job management command-line application
 
@@ -306,23 +311,24 @@ def slurm_runner(run_job, job_spec, filepath=None, onfinish=None, return_index=F
         Function executed for each task specified by ``job_spec``. ``run_job``
         must be of the form ``run_job(metadata, interactive=False, **kwargs)``
         where ``kwargs`` is the set of keyword terms specified by ``job_spec``.
-    
+
     job_spec : tuple of lists of dicts
-        Job specification in the format ``([{kwargs: vals}, ...], [...], ...)``.
+        Job specification in the format ``([{kwargs: vals}, ...], [...], )``.
         ``slurm_runner`` will iterate through all combinations of the lists in
         ``job_spec``, combining paired kwarg dictionaries and passing them as
         arguments to ``run_job``.
-    
+
     filepath : str, optional
-        Path to file to call when running tasks. By default (None), slurm_runner
-        infers the filepath from the location of ``run_job``.
-    
+        Path to file to call when running tasks. By default (None),
+        slurm_runner infers the filepath from the location of ``run_job``.
+
     onfinish : function, optional
-        Provide a function to call when all jobs have been completed. Default (None)
-        takes no action.
-    
+        Provide a function to call when all jobs have been completed. Default
+        (None) takes no action.
+
     return_index : bool, optional
-        Adds a ``task_id`` argument to run_job call with 0-indexed ID of current task
+        Adds a ``task_id`` argument to run_job call with 0-indexed ID of
+        current task
 
     Returns
     -------
@@ -518,7 +524,7 @@ def slurm_runner(run_job, job_spec, filepath=None, onfinish=None, return_index=F
             try:
 
                 job_kwargs = _get_call_args(job_spec, task_id)
-                
+
                 if return_index:
                     job_kwargs.update({'task_id': task_id})
 
@@ -596,9 +602,9 @@ def slurm_runner(run_job, job_spec, filepath=None, onfinish=None, return_index=F
 
         logger.debug('Beginning job\nkwargs:\t{}'.format(
             pprint.pformat(job_kwargs['metadata'], indent=2)))
-                
+
         if return_index:
-             job_kwargs.update({'task_id': task_id})
+            job_kwargs.update({'task_id': task_id})
 
         return run_job(interactive=True, **job_kwargs)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ test_requirements = [
 
 setup(
     name='jrnr',
-    version='0.2.1',
+    version='0.2.2',
     description="Job Runner for Climate Impact Lab Jobs",
     long_description=readme + '\n\n' + history,
     author="Justin Simcock",


### PR DESCRIPTION
 - [x] closes #7 
 - [ ] tests added / passed 👎 
 - [x] docs reflect changes 👍 
 - [ ] passes ``flake8 jrnr tests docs``
 - [x] entry in HISTORY.rst

This adds a new argument to slurm_runner. `return_index` is a boolean flag which allows a run to receive the task_id as a run argument, e.g.: 

```
@slurm_runner(filepath=__file__, job_spec=JOB_SPEC, return_index=True)
def compute(metadata, transformation, task_id=0, interactive=False):
    ...
```