### PR TITLE
update exception behavior for lock file

### DIFF
--- a/jrnr/jrnr.py
+++ b/jrnr/jrnr.py
@@ -534,8 +534,12 @@ def slurm_runner(
                 run_job(**job_kwargs)
 
             except (KeyboardInterrupt, SystemExit):
-                logger.error('{} interupted, removing .lck file before exiting'.format(task_id))
-                os.remove(lock_file.format('lck'))
+                
+                try:
+                    logger.error('{} interupted, removing .lck file before exiting'.format(task_id))
+                    os.remove(lock_file.format('lck'))
+                except:
+                    pass
                 raise
 
             except Exception as e:


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 jrnr tests docs``
 - [ ] entry in HISTORY.rst

Adds more layers of exception handling for lock files when there is a keyboard interrupt. 