### PR TITLE
dedupe toolz in requirements files

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,4 @@
 pip==9.0.1
-toolz==0.8.2
 bumpversion==0.5.3
 wheel==0.30.0
 tox==2.9.1


### PR DESCRIPTION
 - [x] addresses errors encountered in PR #30 
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [x] passes ``flake8 jrnr tests docs``
 - [ ] entry in HISTORY.rst

toolz is required in both requirements_dev and requirements_conda. this removes the entry in requirements_dev