### PR TITLE
Add qos option to run jobs on normal prio

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -101,6 +101,7 @@ Let's first have a look at the options with the run command.
       -d, --dependency INTEGER
       -L, --logdir TEXT            Directory to write log files
       -u, --uniqueid TEXT          Unique job pool id
+      -q, --qos TEXT               QOS setting
       --help                       Show this message and exit.
 
 The most important options are ``u``, ``j`` and ``L``. To specify a job you need ``u`` and ``j`` since these parameters uniquely identify a job and allow you to track the progress of your jobs. An example command is below
@@ -111,13 +112,13 @@ The most important options are ``u``, ``j`` and ``L``. To specify a job you need
 
 This creates a job with a unique id of `001` and a job name of `tas`.
 
-By specifying some of the options listed above, you can adjust the behavior of your slurm jobs. For example, you can put your log files in a specific directory by specifying a value for argument ``L``. Additionally, if you want to use a specific partition on your cluster you can speify the `p` option. Similarly, if your job is particularly compute intensive, with ``n`` you can adjust the number of jobs per node.
+By specifying some of the options listed above, you can adjust the behavior of your slurm jobs. For example, you can put your log files in a specific directory by specifying a value for argument ``L``. Additionally, if you want to use a specific partition on your cluster you can specify the `p` option. Similarly, if your job is particularly compute intensive, with ``n`` you can adjust the number of jobs per node.
 
 .. code-block:: bash
 
     $ python tas.py run -u 001 -j tas -L /logs/tas/ -p savio2_bigmem -n 10
 
-Its important to note that, by default, log files will be written to the directory where you are executing the file. Depending on how large your job is you may want to put these log files elsewhere. 
+It is important to note that, by default, log files will be written to the directory where you are executing the file. Depending on how large your job is you may want to put these log files elsewhere. 
 
 
 If you want to fully take advantage of BRC's computing capacity you can run  

--- a/jrnr/jrnr.py
+++ b/jrnr/jrnr.py
@@ -381,7 +381,7 @@ def slurm_runner(
             jobname='slurm_job',
             dependency=None,
             partition='savio2',
-            qos='savio_lowprio', 
+            qos='savio_lowprio',
             maxnodes=100,
             logdir='log',
             uniqueid='"${SLURM_ARRAY_JOB_ID}"'):
@@ -433,7 +433,6 @@ def slurm_runner(
             maxnodes=100,
             logdir='log',
             uniqueid='"${SLURM_ARRAY_JOB_ID}"'):
-
         if not os.path.isdir(logdir):
             os.makedirs(logdir)
 
@@ -454,7 +453,7 @@ def slurm_runner(
             filepath=filepath,
             jobname=jobname+'_finish',
             partition=partition,
-            qos=qos, 
+            qos=qos,
             dependencies=('afterany', [slurm_id]),
             logdir=logdir,
             flags=['cleanup', slurm_id])
@@ -548,7 +547,6 @@ def slurm_runner(
                 run_job(**job_kwargs)
 
             except (KeyboardInterrupt, SystemExit):
-                
                 try:
                     logger.error('{} interupted, removing .lck file before exiting'.format(task_id))
                     os.remove(lock_file.format('lck'))

--- a/jrnr/jrnr.py
+++ b/jrnr/jrnr.py
@@ -381,7 +381,7 @@ def slurm_runner(
             jobname='slurm_job',
             dependency=None,
             partition='savio2',
-            qos='savio_lowprio'
+            qos='savio_lowprio', 
             maxnodes=100,
             logdir='log',
             uniqueid='"${SLURM_ARRAY_JOB_ID}"'):

--- a/jrnr/jrnr.py
+++ b/jrnr/jrnr.py
@@ -110,7 +110,7 @@ def _prep_slurm(
         filepath,
         jobname='slurm_job',
         partition='savio2',
-        qos='savio2_lowprio',
+        qos='savio_lowprio',
         job_spec=None,
         limit=None,
         uniqueid='"${SLURM_ARRAY_JOB_ID}"',
@@ -178,7 +178,7 @@ def run_slurm(
         filepath,
         jobname='slurm_job',
         partition='savio2',
-        qos='savio2_lowprio',
+        qos='savio_lowprio',
         job_spec=None,
         limit=None,
         uniqueid='"${SLURM_ARRAY_JOB_ID}"',
@@ -368,7 +368,7 @@ def slurm_runner(
     @click.option(
         '--partition', '-p', default='savio2', help='resource on which to run')
     @click.option(
-        '--qos', '-q', default='savio2_lowprio', help='QOS for job')
+        '--qos', '-q', default='savio_lowprio', help='QOS for job')
     @click.option('--dependency', '-d', type=int, multiple=True)
     @click.option(
         '--logdir', '-L', default='log', help='Directory to write log files')
@@ -381,7 +381,7 @@ def slurm_runner(
             jobname='slurm_job',
             dependency=None,
             partition='savio2',
-            qos='savio2_lowprio'
+            qos='savio_lowprio'
             maxnodes=100,
             logdir='log',
             uniqueid='"${SLURM_ARRAY_JOB_ID}"'):
@@ -414,7 +414,7 @@ def slurm_runner(
     @click.option(
         '--partition', '-p', default='savio2', help='resource on which to run')
     @click.option(
-        '--qos', '-q', default='savio2_lowprio', help='QOS for job')
+        '--qos', '-q', default='savio_lowprio', help='QOS for job')
     @click.option(
         '--dependency', '-d', type=int, multiple=True)
     @click.option(
@@ -429,7 +429,7 @@ def slurm_runner(
             jobname='slurm_job',
             dependency=None,
             partition='savio2',
-            qos='savio2_lowprio',
+            qos='savio_lowprio',
             maxnodes=100,
             logdir='log',
             uniqueid='"${SLURM_ARRAY_JOB_ID}"'):

--- a/jrnr/jrnr.py
+++ b/jrnr/jrnr.py
@@ -36,7 +36,7 @@ SLURM_SCRIPT = '''
 #SBATCH --account=co_laika
 #
 # QoS:
-#SBATCH --qos=savio_lowprio
+#SBATCH --qos={qos}
 #
 #SBATCH --nodes=1
 #
@@ -110,6 +110,7 @@ def _prep_slurm(
         filepath,
         jobname='slurm_job',
         partition='savio2',
+        qos='savio2_lowprio',
         job_spec=None,
         limit=None,
         uniqueid='"${SLURM_ARRAY_JOB_ID}"',
@@ -161,6 +162,7 @@ def _prep_slurm(
         f.write(template.format(
             jobname=jobname,
             partition=partition,
+            qos=qos,
             numjobs=numjobs,
             jobs_per_node=jobs_per_node,
             maxnodes=(maxnodes-1),
@@ -176,6 +178,7 @@ def run_slurm(
         filepath,
         jobname='slurm_job',
         partition='savio2',
+        qos='savio2_lowprio',
         job_spec=None,
         limit=None,
         uniqueid='"${SLURM_ARRAY_JOB_ID}"',
@@ -189,6 +192,7 @@ def run_slurm(
         filepath=filepath,
         jobname=jobname,
         partition=partition,
+        qos=qos,
         job_spec=job_spec,
         limit=limit,
         uniqueid=uniqueid,
@@ -363,6 +367,8 @@ def slurm_runner(
         '--jobname', '-j', default='test', help='name of the job')
     @click.option(
         '--partition', '-p', default='savio2', help='resource on which to run')
+    @click.option(
+        '--qos', '-q', default='savio2_lowprio', help='QOS for job')
     @click.option('--dependency', '-d', type=int, multiple=True)
     @click.option(
         '--logdir', '-L', default='log', help='Directory to write log files')
@@ -375,6 +381,7 @@ def slurm_runner(
             jobname='slurm_job',
             dependency=None,
             partition='savio2',
+            qos='savio2_lowprio'
             maxnodes=100,
             logdir='log',
             uniqueid='"${SLURM_ARRAY_JOB_ID}"'):
@@ -383,6 +390,7 @@ def slurm_runner(
             filepath=filepath,
             jobname=jobname,
             partition=partition,
+            qos=qos,
             job_spec=job_spec,
             jobs_per_node=jobs_per_node,
             maxnodes=maxnodes,
@@ -406,18 +414,22 @@ def slurm_runner(
     @click.option(
         '--partition', '-p', default='savio2', help='resource on which to run')
     @click.option(
+        '--qos', '-q', default='savio2_lowprio', help='QOS for job')
+    @click.option(
         '--dependency', '-d', type=int, multiple=True)
     @click.option(
         '--logdir', '-L', default='log', help='Directory to write log files')
     @click.option(
         '--uniqueid', '-u', default='"${SLURM_ARRAY_JOB_ID}"',
         help='Unique job pool id')
+
     def run(
             limit=None,
             jobs_per_node=24,
             jobname='slurm_job',
             dependency=None,
             partition='savio2',
+            qos='savio2_lowprio',
             maxnodes=100,
             logdir='log',
             uniqueid='"${SLURM_ARRAY_JOB_ID}"'):
@@ -429,6 +441,7 @@ def slurm_runner(
             filepath=filepath,
             jobname=jobname,
             partition=partition,
+            qos=qos,
             job_spec=job_spec,
             jobs_per_node=jobs_per_node,
             maxnodes=maxnodes,
@@ -441,6 +454,7 @@ def slurm_runner(
             filepath=filepath,
             jobname=jobname+'_finish',
             partition=partition,
+            qos=qos, 
             dependencies=('afterany', [slurm_id]),
             logdir=logdir,
             flags=['cleanup', slurm_id])


### PR DESCRIPTION
Added a qos option (usage `python tas.py run -q {qos_name}`) so we can run jobs on our normal prio nodes in addition to running on low prio nodes. 